### PR TITLE
SW-193: Updated dependencies (mainly nom)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ keywords = ["redis", "network", "no_std", "database"]
 categories  = ["embedded", "database", "no-std"]
 authors = ["PEGASUS GmbH <info@pegasus-aero.de>"]
 license = "MIT OR Apache-2.0"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 repository = "https://github.com/pegasus-aero/rt-embedded-redis"
 readme = "README.md"
@@ -15,14 +15,14 @@ documentation = "https://docs.rs/embedded-redis"
 embedded-nal = "0.6.0"
 embedded-time = "0.12.1"
 nb = "1.0.0"
-redis-protocol-mm = { version = "4.1.0", default-features = false, features = ["libm", "hashbrown", "alloc"] }
-bytes = { version = "1.1.0", default-features = false }
-mockall = { version = "0.11.0", optional=true }
+redis-protocol-mm = { version = "4.2.0", default-features = false, features = ["libm", "hashbrown", "alloc"] }
+bytes = { version = "1.2.1", default-features = false }
+mockall = { version = "0.11.3", optional=true }
 
 [dev-dependencies]
-std-embedded-nal = "0.1.2"
+std-embedded-nal = "0.1.3"
 std-embedded-time = "0.1.0"
-mockall = { version = "0.11.0" }
+mockall = { version = "0.11.3" }
 
 [features]
 default = []

--- a/src/network/tests/mocks.rs
+++ b/src/network/tests/mocks.rs
@@ -228,7 +228,7 @@ impl NetworkMockBuilder {
         });
 
         self.stack.expect_receive().times(1).returning(move |_, mut buffer: &mut [u8]| {
-            let frame = format!("+{}\r\n:{}\r\n", topic, channel_count);
+            let frame = format!("+{topic}\r\n:{channel_count}\r\n");
             let _ = buffer.write(frame.as_bytes()).unwrap();
             nb::Result::Ok(frame.len())
         });
@@ -245,7 +245,7 @@ impl NetworkMockBuilder {
         });
 
         self.stack.expect_receive().times(1).returning(move |_, mut buffer: &mut [u8]| {
-            let frame = format!("+{}\r\n:{}\r\n", topic, channel_count);
+            let frame = format!("+{topic}\r\n:{channel_count}\r\n");
             let _ = buffer.write(frame.as_bytes()).unwrap();
             nb::Result::Ok(frame.len())
         });
@@ -262,7 +262,7 @@ impl NetworkMockBuilder {
         });
 
         self.stack.expect_receive().times(1).returning(move |_, mut buffer: &mut [u8]| {
-            let frame = format!("+{}\r\n+{}\r\n", channel, payload);
+            let frame = format!("+{channel}\r\n+{payload}\r\n");
             let _ = buffer.write(frame.as_bytes()).unwrap();
             nb::Result::Ok(frame.len())
         });


### PR DESCRIPTION
Updated dependencies, mainly to solve deprecation warning of nom.
See: https://github.com/aembke/redis-protocol.rs/issues/23